### PR TITLE
chore: update GitHub repo and base URL in admin config

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,8 +1,8 @@
 backend:
   name: github
-  repo: your-github-username/akordium
+  repo: akordium-id/web
   branch: main
-  base_url: https://your-deno-deploy-url.deno.dev
+  base_url: https://akordium.id
   auth_endpoint: api/auth
 
 # Publish mode for editorial workflow


### PR DESCRIPTION
The GitHub repository and base URL in the admin configuration file have been updated to reflect the correct values for the production environment. This ensures that the CMS points to the correct repository and deployment URL.